### PR TITLE
feat: add `lineBreak` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,8 @@ declare const clikey: (
   options?: {
     stdout?: ReadStream,
     stdin?: WriteStream,
-    encoding?: 'ascii' | 'utf8' | 'utf-8' | 'utf16le' | 'ucs2' | 'ucs-2' | 'base64' | 'latin1' | 'binary' | 'hex'
+    encoding?: 'ascii' | 'utf8' | 'utf-8' | 'utf16le' | 'ucs2' | 'ucs-2' | 'base64' | 'latin1' | 'binary' | 'hex',
+    lineBreak?: boolean,
   }
 ) => Promise<string>;
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 module.exports = (msg, {
   stdout = process.stdout,
   stdin = process.stdin,
-  encoding = 'utf8'
+  encoding = 'utf8',
+  lineBreak = true,
 } = {}) => new Promise((resolve) => {
   stdout.write(msg);
 
@@ -11,7 +12,9 @@ module.exports = (msg, {
   stdin
     .once('data', data => {
       stdin.pause();
-      stdout.write('\n');
+      if (lineBreak) {
+        stdout.write('\n');
+      }
 
       resolve(`${data || ''}`);
     })


### PR DESCRIPTION
Set `lineBreak: false` to disable automatic line break after a key is pressed.

I think `lineBreak: false` should really be the default, but we can do that in the next major version if you're onboard. This PR can be released in a minor version. 👍 